### PR TITLE
remove precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: name-tests-test
-      - id: no-commit-to-branch
-        args: ['--branch=main']
       - id: trailing-whitespace
 
   - repo: https://github.com/omnilib/ufmt


### PR DESCRIPTION
this pre-commit hook is failing on merge commits since by definition, you're merging a PR into the main branch

to resolve this, we remove this hook and add a branch protection rule on the main branch