### PR TITLE
remove unneeded wrist test partition

### DIFF
--- a/config/data_module/data_split/wrist_mini_split.yaml
+++ b/config/data_module/data_split/wrist_mini_split.yaml
@@ -9,5 +9,4 @@ train:
 val:
   wrist_user_001_dataset_000: null # null means use the entire dataset (no partitioning)
 test:
-  wrist_user_002_dataset_000:
-    - [1713966045.6641605, 1713966207.9896057]
+  wrist_user_002_dataset_000: null # null means use the entire dataset (no partitioning)

--- a/notebooks/wrist-eval.ipynb
+++ b/notebooks/wrist-eval.ipynb
@@ -158,7 +158,7 @@
    "source": [
     "\"\"\"Grab one test stage\"\"\"\n",
     "\n",
-    "test_dataset = datamodule._make_dataset({\"wrist_user_002_dataset_000\": [(1713966045.6641605, 1713966207.9896057)]}, \"test\")  # from wrist_mini_split.yaml\n",
+    "test_dataset = datamodule._make_dataset({\"wrist_user_002_dataset_000\": None}, \"test\")  # from wrist_mini_split.yaml\n",
     "sample = test_dataset[0]"
    ]
   },


### PR DESCRIPTION
Tested both 1 epoch of local training:
`python -m generic_neuromotor_interface.train --config-name=wrist trainer.max_epochs=1 trainer.accelerator=cpu data_module/data_split=wrist_mini_split`

And the eval notebook `wrist-eval.ipynb`

Both worked fine.