### PR TITLE
Add more detail to the directory containing the logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can also launch a small test run (1 epoch on the `small_subset` dataset) via
 python -m generic_neuromotor_interface.train --config-name=<TASK_NAME> trainer.max_epochs=1 trainer.accelerator=cpu data_module/data_split=<TASK_NAME>_mini_split
 ```
 
-After training, the model checkpoint will be available at `logs/.../lightning_logs/.../checkpoints/`, and the model config will be available at `logs/.../hydra_configs/config.yaml`.
+After training, the model checkpoint will be available at `./logs/<DATE>/<TIME>/lightning_logs/<VERSION>/checkpoints/`, and the model config will be available at `./logs/<DATE>/<TIME>/hydra_configs/config.yaml`.
 
 ## Evaluate a model
 


### PR DESCRIPTION
It was unclear to me where the `logs/` directory would be, and then I realized that it was in the location from which I called the command. In retrospect this was obvious, but I only realized after searching around a few places (my initial thought is it would be in the repo directory or in `~/`). I think doesn't hurt to more explicitly state this in the README by prefixing with `./`.