### PR TITLE
Add details about stage information stored in the .csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ We are releasing data from 100 data collection participants for each task: 80 tr
 
 Evaluation metrics may deviate slightly from the published results due to subsampling of the test participants (as there is considerable variability across participants) and variability across model seeds.
 
-Each recording is stored in an `.hdf5` file, and there can be multiple recordings per participant. There is also a `.csv` file for each task (`<TASK_NAME>_corpus.csv`) documenting the recordings included for each participant, start and end times for each relevant "stage" from the experimental protocol (see below), and their assignment to the train / val / test splits. This `.csv` file is downloaded alongside the data using the script described above.
+Each recording is stored in an `.hdf5` file, and there can be multiple recordings per participant. There is also a `.csv` file for each task (`<TASK_NAME>_corpus.csv`) documenting the recordings included for each participant, start and end times for each relevant "stage" from the experimental protocol (see below), and their assignment to the train / val / test splits. This `.csv` file is downloaded alongside the data by the `download_data.sh` script described above.
 
 sEMG is recorded at 2 kHz and is high pass filtered at 40 Hz. Timestamps are expressed in seconds. A `stages` dataframe is included in each dataset that encodes the time of each stage of the experiment (see `explore_data.ipynb` for more details). Specifics for each task are as follows:
 


### PR DESCRIPTION
The README only states that the csv contains info about the datasets and participants and their allocation to train/val/test splits. But when you open up the csv file the first thing that jumps out is a list of start and end times associated with each dataset. I added a clause explaining what this is: start/end times of the "stages" in the experimental protocol, which are then specified further below. I think this also helps clarify what we mean by a "stage", which I don't think is standard terminology (although it's pretty clear from the descriptions below).