### PR TITLE
Remove unused pyre-strict

### DIFF
--- a/generic_neuromotor_interface/__init__.py
+++ b/generic_neuromotor_interface/__init__.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/augmentation.py
+++ b/generic_neuromotor_interface/augmentation.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/cler.py
+++ b/generic_neuromotor_interface/cler.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/constants.py
+++ b/generic_neuromotor_interface/constants.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/data.py
+++ b/generic_neuromotor_interface/data.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/data_module.py
+++ b/generic_neuromotor_interface/data_module.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/explore_data/__init__.py
+++ b/generic_neuromotor_interface/explore_data/__init__.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/explore_data/load.py
+++ b/generic_neuromotor_interface/explore_data/load.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/explore_data/plot.py
+++ b/generic_neuromotor_interface/explore_data/plot.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/handwriting_utils.py
+++ b/generic_neuromotor_interface/handwriting_utils.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/lightning.py
+++ b/generic_neuromotor_interface/lightning.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/networks.py
+++ b/generic_neuromotor_interface/networks.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/tests/test_lightning.py
+++ b/generic_neuromotor_interface/tests/test_lightning.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/tests/test_networks.py
+++ b/generic_neuromotor_interface/tests/test_networks.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/train.py
+++ b/generic_neuromotor_interface/train.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/transforms.py
+++ b/generic_neuromotor_interface/transforms.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/generic_neuromotor_interface/utils.py
+++ b/generic_neuromotor_interface/utils.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# pyre-strict
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #


### PR DESCRIPTION
Summary:
Files in `oss` are meant to be run in an OSS context (think: conda). As such they aren't expected to be checked by Pyre, and residual `# pyre-strict` tags are confusing.

 {F1980268150}

Reviewed By: jamenendez11

Differential Revision: D78307617


