### PR TITLE
use model checkpoint loading in eval nbs, plus other minor changes

### DIFF
--- a/notebooks/discrete_gestures-eval.ipynb
+++ b/notebooks/discrete_gestures-eval.ipynb
@@ -20,12 +20,14 @@
     "from pytorch_lightning import Trainer\n",
     "from hydra import initialize, compose\n",
     "from hydra.utils import instantiate\n",
-    "import omegaconf\n",
+    "from omegaconf import OmegaConf\n",
     "from matplotlib import pyplot as plt\n",
     "import seaborn as sns\n",
     "\n",
     "from generic_neuromotor_interface.cler import GestureType\n",
-    "from generic_neuromotor_interface.cler import compute_cler"
+    "from generic_neuromotor_interface.cler import compute_cler\n",
+    "\n",
+    "TASK_NAME = \"discrete_gestures\""
    ]
   },
   {
@@ -58,50 +60,67 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7bde32f-7f8a-45f7-86f4-085f39c5020a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(os.path.expanduser(EMG_DATA_DIR)):\n",
+    "    raise FileNotFoundError(f\"The EMG data path does not exist: {EMG_DATA_DIR}\")\n",
+    "\n",
+    "if not os.path.exists(os.path.expanduser(MODELS_DIR)):\n",
+    "    raise FileNotFoundError(f\"The models path does not exist: {MODELS_DIR}\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "09138984-111a-435e-b7b4-90c446d10309",
+   "id": "b30a5396-227e-482c-a269-101995844d5c",
    "metadata": {},
    "source": [
-    "## Load model checkpoint and config"
+    "## Load model config"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d16eb69b-2720-4e74-a5e9-a49e5e01ce5b",
+   "id": "990839d8-1d29-4913-bdf2-a82c0c49e209",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"Retrieve model checkpoint\"\"\"\n",
+    "\"\"\"Load model config\"\"\"\n",
     "\n",
-    "model_ckpt_path = os.path.join(os.path.expanduser(MODELS_DIR), \"discrete_gestures\", \"model_checkpoint.ckpt\")\n",
+    "config_path = os.path.join(os.path.expanduser(MODELS_DIR), TASK_NAME, \"model_config.yaml\")\n",
+    "config = OmegaConf.load(config_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ee9fda8-5305-4715-af71-4e7e0afbeba6",
+   "metadata": {},
+   "source": [
+    "## Load model checkpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6b436fe-d5cf-4416-b75b-aaeb4d288216",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Load model checkpoint\"\"\"\n",
     "\n",
-    "if not os.path.exists(model_ckpt_path):\n",
-    "    raise FileNotFoundError(f\"The model checkpoint path does not exist: {model_ckpt_path}\")\n",
-    "\n",
-    "model_ckpt = torch.load(\n",
+    "model_ckpt_path = os.path.join(\n",
+    "    os.path.expanduser(MODELS_DIR),\n",
+    "    TASK_NAME,\n",
+    "    \"model_checkpoint.ckpt\"\n",
+    ")\n",
+    "model = instantiate(config.lightning_module)\n",
+    "model = model.load_from_checkpoint(\n",
     "    model_ckpt_path,\n",
     "    map_location=torch.device(\"cpu\"),\n",
-    "    weights_only=False\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "df1f36ae-f1f3-4488-846a-70e969a95cf1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"\"\"Retrieve the config\"\"\"\n",
-    "\n",
-    "config_path = os.path.join(os.path.expanduser(MODELS_DIR), \"discrete_gestures\")\n",
-    "\n",
-    "if not os.path.exists(config_path):\n",
-    "    raise FileNotFoundError(f\"The config path does not exist: {config_path}\")\n",
-    "\n",
-    "with initialize(config_path=os.path.relpath(config_path), version_base=\"1.1\"):\n",
-    "    cfg = compose(config_name=\"model_config\")"
    ]
   },
   {
@@ -109,23 +128,7 @@
    "id": "765e9500-1ca2-4392-b268-515159db4a52",
    "metadata": {},
    "source": [
-    "## Instantiate model and data module"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dda10e70-6ebf-40ab-b0e4-563bc84d7467",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"\"\"Load the model\"\"\"\n",
-    "\n",
-    "# Instantiate model\n",
-    "model = instantiate(cfg.lightning_module)\n",
-    "\n",
-    "# Load the checkpoint state_dict\n",
-    "model.load_state_dict(model_ckpt[\"state_dict\"])"
+    "## Instantiate data module"
    ]
   },
   {
@@ -137,19 +140,15 @@
    "source": [
     "\"\"\"Assemble the data module\"\"\"\n",
     "\n",
-    "data_path = os.path.expanduser(EMG_DATA_DIR)\n",
+    "# Update DataModule config with data path\n",
+    "config[\"data_module\"][\"data_location\"] = os.path.expanduser(EMG_DATA_DIR)\n",
+    "if \"from_csv\" in config[\"data_module\"][\"data_split\"][\"_target_\"]:\n",
+    "    config[\"data_module\"][\"data_split\"][\"csv_filename\"] = os.path.join(\n",
+    "        os.path.expanduser(EMG_DATA_DIR),\n",
+    "        f\"{TASK_NAME}_corpus.csv\"\n",
+    "    )\n",
     "\n",
-    "if not os.path.exists(data_path):\n",
-    "    raise FileNotFoundError(f\"The EMG data path does not exist: {data_path}\")\n",
-    "\n",
-    "# Assemble DataModule config\n",
-    "datamodule_cfg = omegaconf.OmegaConf.to_container(cfg.data_module)\n",
-    "datamodule_cfg[\"data_location\"] = EMG_DATA_DIR\n",
-    "if \"from_csv\" in datamodule_cfg[\"data_split\"][\"_target_\"]:\n",
-    "    datamodule_cfg[\"data_split\"][\"csv_filename\"] = os.path.join(data_path, \"discrete_gestures_corpus.csv\")\n",
-    "\n",
-    "# Instantiate DataModule\n",
-    "datamodule = instantiate(datamodule_cfg)"
+    "datamodule = instantiate(config[\"data_module\"])"
    ]
   },
   {
@@ -325,7 +324,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer = Trainer()\n",
+    "trainer = Trainer(accelerator=\"cpu\")\n",
     "test_results = trainer.test(model=model, datamodule=datamodule)"
    ]
   }

--- a/notebooks/handwriting-eval.ipynb
+++ b/notebooks/handwriting-eval.ipynb
@@ -20,9 +20,11 @@
     "from pytorch_lightning import Trainer\n",
     "from hydra import initialize, compose\n",
     "from hydra.utils import instantiate\n",
-    "import omegaconf\n",
+    "from omegaconf import OmegaConf\n",
     "\n",
-    "from generic_neuromotor_interface.handwriting_utils import CharacterErrorRates"
+    "from generic_neuromotor_interface.handwriting_utils import CharacterErrorRates\n",
+    "\n",
+    "TASK_NAME = \"handwriting\""
    ]
   },
   {
@@ -55,50 +57,67 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97c3bfae-0335-4ef1-b182-e28a0d4cac24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(os.path.expanduser(EMG_DATA_DIR)):\n",
+    "    raise FileNotFoundError(f\"The EMG data path does not exist: {EMG_DATA_DIR}\")\n",
+    "\n",
+    "if not os.path.exists(os.path.expanduser(MODELS_DIR)):\n",
+    "    raise FileNotFoundError(f\"The models path does not exist: {MODELS_DIR}\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "f685fb01-6d92-449f-9077-efdceaea76e8",
+   "id": "bbf3f201-0006-4ec9-a5bf-6a8583a1b450",
    "metadata": {},
    "source": [
-    "## Load model checkpoint and config"
+    "## Load model config"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62520582-959d-4883-9b67-db8df4266bcd",
+   "id": "5220619a-3102-49bc-8c8b-e608c8bc9ea4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"Retrieve model checkpoint\"\"\"\n",
+    "\"\"\"Load model config\"\"\"\n",
     "\n",
-    "model_ckpt_path = os.path.join(os.path.expanduser(MODELS_DIR), \"handwriting\", \"model_checkpoint.ckpt\")\n",
+    "config_path = os.path.join(os.path.expanduser(MODELS_DIR), TASK_NAME, \"model_config.yaml\")\n",
+    "config = OmegaConf.load(config_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a40cf1f5-d667-44a4-b7bd-3f0b1af56909",
+   "metadata": {},
+   "source": [
+    "## Load model checkpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19766bb3-a366-4a9b-a118-f9923d343ab5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Load model checkpoint\"\"\"\n",
     "\n",
-    "if not os.path.exists(model_ckpt_path):\n",
-    "    raise FileNotFoundError(f\"The model checkpoint path does not exist: {model_ckpt_path}\")\n",
-    "\n",
-    "model_ckpt = torch.load(\n",
+    "model_ckpt_path = os.path.join(\n",
+    "    os.path.expanduser(MODELS_DIR),\n",
+    "    TASK_NAME,\n",
+    "    \"model_checkpoint.ckpt\"\n",
+    ")\n",
+    "model = instantiate(config.lightning_module)\n",
+    "model = model.load_from_checkpoint(\n",
     "    model_ckpt_path,\n",
     "    map_location=torch.device(\"cpu\"),\n",
-    "    weights_only=False\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "128b6098-7457-4801-957c-2af34091bc81",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"\"\"Retrieve the config\"\"\"\n",
-    "\n",
-    "config_path = os.path.join(os.path.expanduser(MODELS_DIR), \"handwriting\")\n",
-    "\n",
-    "if not os.path.exists(config_path):\n",
-    "    raise FileNotFoundError(f\"The config path does not exist: {config_path}\")\n",
-    "\n",
-    "with initialize(config_path=os.path.relpath(config_path), version_base=\"1.1\"):\n",
-    "    cfg = compose(config_name=\"model_config\")"
    ]
   },
   {
@@ -106,23 +125,7 @@
    "id": "44b3b308-0713-419e-9af3-37fa36274909",
    "metadata": {},
    "source": [
-    "## Instantiate model and data module"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "78e724a0-08eb-4607-a9fc-5e272fe75d47",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"\"\"Load the model\"\"\"\n",
-    "\n",
-    "# Instantiate model\n",
-    "model = instantiate(cfg.lightning_module)\n",
-    "\n",
-    "# Load the checkpoint state_dict\n",
-    "model.load_state_dict(model_ckpt[\"state_dict\"])"
+    "## Instantiate data module"
    ]
   },
   {
@@ -134,19 +137,15 @@
    "source": [
     "\"\"\"Assemble the data module\"\"\"\n",
     "\n",
-    "data_path = os.path.expanduser(EMG_DATA_DIR)\n",
+    "# Update DataModule config with data path\n",
+    "config[\"data_module\"][\"data_location\"] = os.path.expanduser(EMG_DATA_DIR)\n",
+    "if \"from_csv\" in config[\"data_module\"][\"data_split\"][\"_target_\"]:\n",
+    "    config[\"data_module\"][\"data_split\"][\"csv_filename\"] = os.path.join(\n",
+    "        os.path.expanduser(EMG_DATA_DIR),\n",
+    "        f\"{TASK_NAME}_corpus.csv\"\n",
+    "    )\n",
     "\n",
-    "if not os.path.exists(data_path):\n",
-    "    raise FileNotFoundError(f\"The EMG data path does not exist: {data_path}\")\n",
-    "\n",
-    "# Assemble DataModule config\n",
-    "datamodule_cfg = omegaconf.OmegaConf.to_container(cfg.data_module)\n",
-    "datamodule_cfg[\"data_location\"] = EMG_DATA_DIR\n",
-    "if \"from_csv\" in datamodule_cfg[\"data_split\"][\"_target_\"]:\n",
-    "    datamodule_cfg[\"data_split\"][\"csv_filename\"] = os.path.join(data_path, \"handwriting_corpus.csv\")\n",
-    "\n",
-    "# Instantiate DataModule\n",
-    "datamodule = instantiate(datamodule_cfg)"
+    "datamodule = instantiate(config[\"data_module\"])"
    ]
   },
   {
@@ -255,7 +254,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer = Trainer()\n",
+    "trainer = Trainer(accelerator=\"cpu\")\n",
     "test_results = trainer.test(model=model, datamodule=datamodule)"
    ]
   }

--- a/notebooks/wrist-eval.ipynb
+++ b/notebooks/wrist-eval.ipynb
@@ -26,9 +26,11 @@
     "from pytorch_lightning import Trainer\n",
     "from hydra import initialize, compose\n",
     "from hydra.utils import instantiate\n",
-    "import omegaconf\n",
+    "from omegaconf import OmegaConf\n",
     "from matplotlib import pyplot as plt\n",
-    "import seaborn as sns"
+    "import seaborn as sns\n",
+    "\n",
+    "TASK_NAME = \"wrist\""
    ]
   },
   {
@@ -61,32 +63,25 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00a3fc63-aeb6-4512-8633-460885aa5777",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(os.path.expanduser(EMG_DATA_DIR)):\n",
+    "    raise FileNotFoundError(f\"The EMG data path does not exist: {EMG_DATA_DIR}\")\n",
+    "\n",
+    "if not os.path.exists(os.path.expanduser(MODELS_DIR)):\n",
+    "    raise FileNotFoundError(f\"The models path does not exist: {MODELS_DIR}\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9012043a-a26f-4ebb-8d7e-7bb8394e2102",
    "metadata": {},
    "source": [
-    "## Load model checkpoint and config"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "94158108-3d28-4fa5-816d-b28b9a93b4dd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"\"\"Retrieve model checkpoint\"\"\"\n",
-    "\n",
-    "model_ckpt_path = os.path.join(os.path.expanduser(MODELS_DIR), \"wrist\", \"model_checkpoint.ckpt\")\n",
-    "\n",
-    "if not os.path.exists(model_ckpt_path):\n",
-    "    raise FileNotFoundError(f\"The model checkpoint path does not exist: {model_ckpt_path}\")\n",
-    "\n",
-    "model_ckpt = torch.load(\n",
-    "    model_ckpt_path,\n",
-    "    map_location=torch.device(\"cpu\"),\n",
-    "    weights_only=False\n",
-    ")"
+    "## Load model config"
    ]
   },
   {
@@ -96,15 +91,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"Retrieve the config\"\"\"\n",
+    "\"\"\"Load model config\"\"\"\n",
     "\n",
-    "config_path = os.path.join(os.path.expanduser(MODELS_DIR), \"wrist\")\n",
+    "config_path = os.path.join(os.path.expanduser(MODELS_DIR), TASK_NAME, \"model_config.yaml\")\n",
+    "config = OmegaConf.load(config_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab2b42c1-a239-4602-97a9-8d215f15c9e0",
+   "metadata": {},
+   "source": [
+    "## Load model checkpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4c4a3c5-9b66-473c-8f3a-8ecf5aba0ff7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Load model checkpoint\"\"\"\n",
     "\n",
-    "if not os.path.exists(config_path):\n",
-    "    raise FileNotFoundError(f\"The config path does not exist: {config_path}\")\n",
-    "\n",
-    "with initialize(config_path=os.path.relpath(config_path), version_base=\"1.1\"):\n",
-    "    cfg = compose(config_name=\"model_config\")"
+    "model_ckpt_path = os.path.join(\n",
+    "    os.path.expanduser(MODELS_DIR),\n",
+    "    TASK_NAME,\n",
+    "    \"model_checkpoint.ckpt\"\n",
+    ")\n",
+    "model = instantiate(config.lightning_module)\n",
+    "model = model.load_from_checkpoint(\n",
+    "    model_ckpt_path,\n",
+    "    map_location=torch.device(\"cpu\"),\n",
+    ")"
    ]
   },
   {
@@ -112,23 +131,7 @@
    "id": "cef228a4-ca64-4954-891a-942ab5cb2e0c",
    "metadata": {},
    "source": [
-    "## Instantiate model and data module"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c2e8b392-ef4f-49d5-ac09-141623835245",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\"\"\"Load the model\"\"\"\n",
-    "\n",
-    "# Instantiate model\n",
-    "model = instantiate(cfg.lightning_module)\n",
-    "\n",
-    "# Load the checkpoint state_dict\n",
-    "model.load_state_dict(model_ckpt[\"state_dict\"])"
+    "## Instantiate data module"
    ]
   },
   {
@@ -140,19 +143,15 @@
    "source": [
     "\"\"\"Assemble the data module\"\"\"\n",
     "\n",
-    "data_path = os.path.expanduser(EMG_DATA_DIR)\n",
+    "# Update DataModule config with data path\n",
+    "config[\"data_module\"][\"data_location\"] = os.path.expanduser(EMG_DATA_DIR)\n",
+    "if \"from_csv\" in config[\"data_module\"][\"data_split\"][\"_target_\"]:\n",
+    "    config[\"data_module\"][\"data_split\"][\"csv_filename\"] = os.path.join(\n",
+    "        os.path.expanduser(EMG_DATA_DIR),\n",
+    "        f\"{TASK_NAME}_corpus.csv\"\n",
+    "    )\n",
     "\n",
-    "if not os.path.exists(data_path):\n",
-    "    raise FileNotFoundError(f\"The EMG data path does not exist: {data_path}\")\n",
-    "\n",
-    "# Assemble DataModule config\n",
-    "datamodule_cfg = omegaconf.OmegaConf.to_container(cfg.data_module)\n",
-    "datamodule_cfg[\"data_location\"] = EMG_DATA_DIR\n",
-    "if \"from_csv\" in datamodule_cfg[\"data_split\"][\"_target_\"]:\n",
-    "    datamodule_cfg[\"data_split\"][\"csv_filename\"] = os.path.join(data_path, \"wrist_corpus.csv\")\n",
-    "\n",
-    "# Instantiate DataModule\n",
-    "datamodule = instantiate(datamodule_cfg)"
+    "datamodule = instantiate(config[\"data_module\"])"
    ]
   },
   {
@@ -324,7 +323,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer = Trainer()\n",
+    "trainer = Trainer(accelerator=\"cpu\")\n",
     "test_results = trainer.test(model=model, datamodule=datamodule)"
    ]
   }


### PR DESCRIPTION
Summary:
Switch from loading in the state dict, to more standard way of loading in the model from a checkpoint

Also makes some minor changes to make the notebooks more uniform, and adds explicit overrides in the config loading, rather than manual edits to the loaded config.

Reviewed By: schlagercollin

Differential Revision: D78357851


