### PR TITLE
fix boolean environment variables

### DIFF
--- a/generic_neuromotor_interface/tests/test_integration.py
+++ b/generic_neuromotor_interface/tests/test_integration.py
@@ -35,8 +35,8 @@ from omegaconf import DictConfig, OmegaConf
 
 
 # for now, we keep these os OS env vars for manual modification
-USE_REAL_DATA = os.environ.get("USE_REAL_DATA", False)
-USE_REAL_CHECKPOINTS = os.environ.get("USE_REAL_CHECKPOINTS", False)
+USE_REAL_DATA = os.environ.get("USE_REAL_DATA", "False").lower() == "true"
+USE_REAL_CHECKPOINTS = os.environ.get("USE_REAL_CHECKPOINTS", "False").lower() == "true"
 
 
 # Define fixtures for integration tests


### PR DESCRIPTION
Summary:
Environment variables are always retrieved as strings. So even when using USE_REAL_DATA=False, in the Python code this was stored as "False" which is truthy.

So, without specifying either of these environment variables from the command line, L38-39 would correctly set the USE_REAL_DATA and USE_REAL_CHECKOINTS constnants to False. But when specifying them from the command line, they were always yielding a truthy value, so real data and real checkpoitns were being used regardless of whether True or False was assigned to those environment variables from the command line.

Differential Revision: D78483314


