### PR TITLE
simplify reference metric checks

### DIFF
--- a/generic_neuromotor_interface/tests/test_integration.py
+++ b/generic_neuromotor_interface/tests/test_integration.py
@@ -250,7 +250,7 @@ def _test_task_train_mini_subset_cpu(task_name, dataset_dir):
     # match expected
     key = "real_data" if USE_REAL_DATA else "mock_data"
     assert results["best_checkpoint_score"] == pytest.approx(
-        REFERENCE_TRAIN_RESULTS[task_name][key]
+        TRAIN_REFERENCE_RESULTS[task_name][key]
     )
 
 
@@ -294,20 +294,20 @@ def _test_task_evaluate_mini_subset_cpu(task_name, dataset_dir, checkpoint_dir):
     assert "test_metrics" in results
 
     # Check that the results match expected
-    checkpoint_key = "real_checkpoint" if USE_REAL_CHECKPOINTS else "mock_checkpoint"
-    data_key = "real_data" if USE_REAL_DATA else "mock_data"
-    for key, metrics in results.items():
-        if key == "checkpoint_path":
-            continue
-        for metric_name, metric_value in metrics[0].items():
-            assert metric_value == pytest.approx(
-                REFERENCE_EVALUATE_RESULTS[task_name][checkpoint_key][data_key][key][
-                    metric_name
-                ]
-            )
+    reference_results = (
+        EVALUATE_REAL_CHECKPOINT_REFERENCE_RESULTS
+        if USE_REAL_CHECKPOINTS
+        else EVALUATE_MOCK_CHECKPOINT_REFERENCE_RESULTS
+    )
+    key = "real_data" if USE_REAL_DATA else "mock_data"
+    for metric, value in reference_results[task_name][key].items():
+        if "val" in metric:
+            assert results["val_metrics"][0][metric] == pytest.approx(value)
+        else:
+            assert results["test_metrics"][0][metric] == pytest.approx(value)
 
 
-REFERENCE_TRAIN_RESULTS = {
+TRAIN_REFERENCE_RESULTS = {
     "wrist": {
         "real_data": 0.09340763092041016,
         "mock_data": 0.7156573534011841,
@@ -323,167 +323,69 @@ REFERENCE_TRAIN_RESULTS = {
 }
 
 
-REFERENCE_EVALUATE_RESULTS = {
+EVALUATE_REAL_CHECKPOINT_REFERENCE_RESULTS = {
     "wrist": {
-        "real_checkpoint": {
-            "real_data": {
-                "val_metrics": {
-                    "val_loss": 0.0029304532799869776,
-                    "val_mae_deg_per_sec": 8.395130315569341,
-                },
-                "test_metrics": {
-                    "test_loss": 0.0038713905960321426,
-                    "test_mae_deg_per_sec": 11.0907170999639,
-                },
-            },
-            "mock_data": {
-                "val_metrics": {
-                    "val_loss": 0.6564533114433289,
-                    "val_mae_deg_per_sec": 1880.6002096544867,
-                },
-                "test_metrics": {
-                    "test_loss": 0.6552098393440247,
-                    "test_mae_deg_per_sec": 1877.0379244928663,
-                },
-            },
+        "real_data": {
+            "val_loss": 0.0029304532799869776,
+            "test_loss": 0.0038713905960321426,
         },
-        "mock_checkpoint": {
-            "real_data": {
-                "val_metrics": {
-                    "val_loss": 0.053083404898643494,
-                    "val_mae_deg_per_sec": 152.07275439936708,
-                },
-                "test_metrics": {
-                    "test_loss": 0.05673551186919212,
-                    "test_mae_deg_per_sec": 162.53526893095486,
-                },
-            },
-            "mock_data": {
-                "val_metrics": {
-                    "val_loss": 0.6570016741752625,
-                    "val_mae_deg_per_sec": 1882.1711531635895,
-                },
-                "test_metrics": {
-                    "test_loss": 0.6555290222167969,
-                    "test_mae_deg_per_sec": 1877.952316068002,
-                },
-            },
+        "mock_data": {
+            "val_loss": 0.6564533114433289,
+            "test_loss": 0.6552098393440247,
         },
     },
     "discrete_gestures": {
-        "real_checkpoint": {
-            "real_data": {
-                "val_metrics": {
-                    "val_accuracy": 0.556594967842102,
-                    "val_loss": 0.010263126343488693,
-                },
-                "test_metrics": {
-                    "test_cler": 0.13421496748924255,
-                    "test_loss": 0.00941223930567503,
-                },
-            },
-            "mock_data": {
-                "val_metrics": {
-                    "val_accuracy": 0.125,
-                    "val_loss": 0.030532492324709892,
-                },
-                "test_metrics": {
-                    "test_cler": 0.0,
-                    "test_loss": 0.030042458325624466,
-                },
-            },
+        "real_data": {
+            "val_loss": 0.010263126343488693,
+            "test_loss": 0.00941223930567503,
         },
-        "mock_checkpoint": {
-            "real_data": {
-                "val_metrics": {
-                    "val_accuracy": 0.1140170618891716,
-                    "val_loss": 0.7204136848449707,
-                },
-                "test_metrics": {
-                    "test_cler": 0.6722221970558167,
-                    "test_loss": 0.7186295390129089,
-                },
-            },
-            "mock_data": {
-                "val_metrics": {
-                    "val_loss": 0.7293607592582703,
-                    "val_accuracy": 0.1428571492433548,
-                },
-                "test_metrics": {
-                    "test_loss": 0.7633956670761108,
-                    "test_cler": 0.6666666865348816,
-                },
-            },
+        "mock_data": {
+            "val_loss": 0.030532492324709892,
+            "test_loss": 0.030042458325624466,
         },
     },
     "handwriting": {
-        "real_checkpoint": {
-            "real_data": {
-                "val_metrics": {
-                    "val/CER": 21.750322341918945,
-                    "val/DER": 4.247104167938232,
-                    "val/IER": 5.53410530090332,
-                    "val/SER": 11.969112396240234,
-                    "val_loss": 0.6563571095466614,
-                },
-                "test_metrics": {
-                    "test/CER": 66.04045867919922,
-                    "test/DER": 0.8670520186424255,
-                    "test/IER": 34.10404586791992,
-                    "test/SER": 31.069364547729492,
-                    "test_loss": 5.226099491119385,
-                },
-            },
-            "mock_data": {
-                "val_metrics": {
-                    "val/CER": 100.0,
-                    "val/DER": 0.0,
-                    "val/IER": 100.0,
-                    "val/SER": 0.0,
-                    "val_loss": 0.0,
-                },
-                "test_metrics": {
-                    "test/CER": 100.0,
-                    "test/DER": 0.0,
-                    "test/IER": 100.0,
-                    "test/SER": 0.0,
-                    "test_loss": 0.0,
-                },
-            },
+        "real_data": {
+            "val/CER": 21.750322341918945,
+            "test/CER": 66.04045867919922,
         },
-        "mock_checkpoint": {
-            "real_data": {
-                "val_metrics": {
-                    "val/CER": 104.24710083007812,
-                    "val/DER": 5.276705265045166,
-                    "val/IER": 84.04118347167969,
-                    "val/SER": 14.929214477539062,
-                    "val_loss": 49.96033477783203,
-                },
-                "test_metrics": {
-                    "test/CER": 103.68497467041016,
-                    "test/DER": 4.190751552581787,
-                    "test/IER": 83.16474151611328,
-                    "test/SER": 16.329479217529297,
-                    "test_loss": 18.270498275756836,
-                },
-            },
-            "mock_data": {
-                "val_metrics": {
-                    "val/CER": 96.38554382324219,
-                    "val/DER": 0.0,
-                    "val/IER": 94.57831573486328,
-                    "val/SER": 1.807228922843933,
-                    "val_loss": 0.0,
-                },
-                "test_metrics": {
-                    "test/CER": 96.38554382324219,
-                    "test/DER": 0.0,
-                    "test/IER": 94.57831573486328,
-                    "test/SER": 1.807228922843933,
-                    "test_loss": 0.0,
-                },
-            },
+        "mock_data": {
+            "val/CER": 100.0,
+            "test/CER": 100.0,
+        },
+    },
+}
+
+
+EVALUATE_MOCK_CHECKPOINT_REFERENCE_RESULTS = {
+    "wrist": {
+        "real_data": {
+            "val_loss": 0.053083404898643494,
+            "test_loss": 0.05673551186919212,
+        },
+        "mock_data": {
+            "val_loss": 0.6570016741752625,
+            "test_loss": 0.6555290222167969,
+        },
+    },
+    "discrete_gestures": {
+        "real_data": {
+            "val_loss": 0.7204136848449707,
+            "test_loss": 0.7186295390129089,
+        },
+        "mock_data": {
+            "val_loss": 0.7293607592582703,
+            "test_loss": 0.7633956670761108,
+        },
+    },
+    "handwriting": {
+        "real_data": {
+            "val/CER": 104.24710083007812,
+            "test/CER": 103.68497467041016,
+        },
+        "mock_data": {
+            "val/CER": 96.38554382324219,
+            "test/CER": 96.38554382324219,
         },
     },
 }


### PR DESCRIPTION
Summary: To simplify the code, test against only one test and val metric per task. Using CER for Handwriting since it doesn't go to 0.0 on the mock checkpoint and mock data, like the loss does.

Differential Revision: D78494689


