### PR TITLE
factor out private method _make_dataset into its own function

### DIFF
--- a/notebooks/discrete_gestures-eval.ipynb
+++ b/notebooks/discrete_gestures-eval.ipynb
@@ -24,8 +24,8 @@
     "from matplotlib import pyplot as plt\n",
     "import seaborn as sns\n",
     "\n",
-    "from generic_neuromotor_interface.cler import GestureType\n",
-    "from generic_neuromotor_interface.cler import compute_cler\n",
+    "from generic_neuromotor_interface.cler import GestureType, compute_cler\n",
+    "from generic_neuromotor_interface.data import make_dataset\n",
     "\n",
     "TASK_NAME = \"discrete_gestures\""
    ]
@@ -168,7 +168,16 @@
    "source": [
     "\"\"\"Grab one test dataset\"\"\"\n",
     "\n",
-    "test_dataset = datamodule._make_dataset({\"discrete_gestures_user_002_dataset_000\": None}, \"test\")  # from discrete_gestures_mini_split.yaml\n",
+    "test_dataset = make_dataset(\n",
+    "    datamodule.data_location,\n",
+    "    partition_dict={\"discrete_gestures_user_002_dataset_000\": None},  # from discrete_gestures_mini_split.yaml\n",
+    "    transform=datamodule.transform,\n",
+    "    emg_augmentation=None,\n",
+    "    window_length=None,\n",
+    "    stride=None,\n",
+    "    jitter=False,\n",
+    ")\n",
+    "\n",
     "sample = test_dataset[0]"
    ]
   },

--- a/notebooks/wrist-eval.ipynb
+++ b/notebooks/wrist-eval.ipynb
@@ -30,6 +30,8 @@
     "from matplotlib import pyplot as plt\n",
     "import seaborn as sns\n",
     "\n",
+    "from generic_neuromotor_interface.data import make_dataset\n",
+    "\n",
     "TASK_NAME = \"wrist\""
    ]
   },
@@ -171,7 +173,18 @@
    "source": [
     "\"\"\"Grab one test stage\"\"\"\n",
     "\n",
-    "test_dataset = datamodule._make_dataset({\"wrist_user_002_dataset_000\": [(1713966045.6641605, 1713966207.9896057)]}, \"test\")  # from wrist_mini_split.yaml\n",
+    "test_dataset = make_dataset(\n",
+    "    datamodule.data_location,\n",
+    "    partition_dict={\n",
+    "        \"wrist_user_002_dataset_000\": [(1713966045.6641605, 1713966207.9896057)]  # from wrist_mini_split.yaml\n",
+    "    },\n",
+    "    transform=datamodule.transform,\n",
+    "    emg_augmentation=None,\n",
+    "    window_length=None,\n",
+    "    stride=None,\n",
+    "    jitter=False,\n",
+    ")\n",
+    "\n",
     "sample = test_dataset[0]"
    ]
   },


### PR DESCRIPTION
Summary:
The DataModule _make_dataset method is a private method, but is useful for offline analysis and used in the eval notebooks so we should make it public

Here, we factor it out into its own function inside data.py. This makes it public, and also helps expose more explicitly what changes between the "train"/"val"/"test" datasets. Rather than switching between different jitter/window_length/stride values with one-line if/else statements, here we explicitly change the values of the arguements sent to `make_dataset`

TODO: add docstring to make_dataset

Reviewed By: schlagercollin

Differential Revision: D78435129


