### PR TITLE
refactor handwriting dataset and make explicit that partition times are unused

### DIFF
--- a/notebooks/handwriting-eval.ipynb
+++ b/notebooks/handwriting-eval.ipynb
@@ -22,6 +22,7 @@
     "from hydra.utils import instantiate\n",
     "from omegaconf import OmegaConf\n",
     "\n",
+    "from generic_neuromotor_interface.data import make_handwriting_dataset\n",
     "from generic_neuromotor_interface.handwriting_utils import CharacterErrorRates\n",
     "\n",
     "TASK_NAME = \"handwriting\""
@@ -165,7 +166,16 @@
    "source": [
     "\"\"\"Grab one test prompt\"\"\"\n",
     "\n",
-    "test_dataset = datamodule._make_dataset({\"handwriting_user_001_dataset_000\": None}, \"test\")  # from handwriting_mini_split.yaml\n",
+    "test_dataset = make_handwriting_dataset(\n",
+    "    dataset_names=[\"handwriting_user_001_dataset_000\"],\n",
+    "    data_location=datamodule.data_location,\n",
+    "    transform=datamodule.transform,\n",
+    "    padding=datamodule.padding,\n",
+    "    emg_augmentation=None,\n",
+    "    concatenate_prompts=False,\n",
+    "    min_duration_s=0.0,\n",
+    ")\n",
+    "\n",
     "sample = test_dataset[55]  # an arbitrary prompt from this dataset"
    ]
   },


### PR DESCRIPTION
Summary:
* Factors out the _make_dataset private method into its own function and updates eval notebook to use this
* Cleans up the padding logic to make it more transparent and avoid redundant checks
* Removes the unused `jitter` argument
* Replaces the `partitions_dict: dict[str, tuple]` argument and replaces it with `dataset_names: list[str]` since the partitions weren't being used at all, only the dataset names. That's becuase in handwriting we just take windows triggered on the prompts, rather than within certain partitions.
* Cleans up some wrong type annotations and docstrings

Differential Revision: D78436663


