### PR TITLE
Run full CI on main commits; restrict full CI to PRs with specific labels

### DIFF
--- a/.github/workflows/integration_cpu.yml
+++ b/.github/workflows/integration_cpu.yml
@@ -8,9 +8,15 @@ name: CPU Integration Tests (Real Data)
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, labeled]
+  push:
+    branches:
+      - main
+
 
 jobs:
-  build-linux:
+  cpu-integration-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'run-full-ci-cpu')
     runs-on: 8-core-ubuntu
 
     steps:

--- a/.github/workflows/integration_gpu.yml
+++ b/.github/workflows/integration_gpu.yml
@@ -8,9 +8,14 @@ name: GPU Integration Tests (Real Data)
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, labeled]
+  push:
+    branches:
+      - main
 
 jobs:
-  build-linux:
+  gpu-integration-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'run-full-ci-gpu')
     runs-on: 4-core-ubuntu-gpu-t4
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  build-linux:
+  linux-ci:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Summary:
* Full GPU / CPU CI runs on every commit pushed to main
* Long CPU CI only run on PRs with tag: `run-full-ci-cpu`
* Long GPU CI only run on PRs with tag: `run-full-ci-gpu`

Differential Revision: D78676233
