### PR TITLE
Update to CC BY-NC 4.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -50,7 +50,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================


### PR DESCRIPTION
Updating to the appropriate license: `CC BY-NC`.

Previously we had CC BY-NC-SA` which is what was approved for emg2pose. It's a different license. 

License from: https://www.internalfb.com/wiki/Open_Source/Licenses/FAIR_License/